### PR TITLE
Add a recursion-depth limit to the Rust backend

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,13 +31,10 @@ struct Decoder {
     max_depth: usize,
 }
 
-// Read the interpreter's recursion limit so both backends fail on the same
-// deeply nested input (the pure-Python backend raises RecursionError).
-fn recursion_limit(py: Python) -> PyResult<usize> {
-    py.import("sys")?
-        .getattr("getrecursionlimit")?
-        .call0()?
-        .extract()
+// Read per instance rather than once, since sys.setrecursionlimit can lower it.
+fn recursion_limit(_py: Python) -> usize {
+    // SAFETY: the GIL is held, as proven by the Python token.
+    unsafe { pyo3::ffi::Py_GetRecursionLimit().max(0) as usize }
 }
 
 #[pymethods]
@@ -54,7 +51,7 @@ impl Decoder {
             yield_tuples: yield_tuples.unwrap_or(false),
             bytestring_encoding,
             depth: 0,
-            max_depth: recursion_limit(s.py())?,
+            max_depth: recursion_limit(s.py()),
         })
     }
 
@@ -308,7 +305,7 @@ impl Encoder {
             buffer: Vec::new(),
             bytestring_encoding,
             depth: 0,
-            max_depth: recursion_limit(py)?,
+            max_depth: recursion_limit(py),
         })
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 #![allow(non_snake_case)]
-use pyo3::exceptions::{PyTypeError, PyValueError};
+use pyo3::exceptions::{PyRecursionError, PyTypeError, PyValueError};
 use pyo3::prelude::*;
 use pyo3::types::{PyBytes, PyDict, PyInt, PyList, PyString, PyTuple};
 
@@ -27,6 +27,17 @@ struct Decoder {
     position: usize,
     yield_tuples: bool,
     bytestring_encoding: Option<String>,
+    depth: usize,
+    max_depth: usize,
+}
+
+// Read the interpreter's recursion limit so both backends fail on the same
+// deeply nested input (the pure-Python backend raises RecursionError).
+fn recursion_limit(py: Python) -> PyResult<usize> {
+    py.import("sys")?
+        .getattr("getrecursionlimit")?
+        .call0()?
+        .extract()
 }
 
 #[pymethods]
@@ -36,13 +47,15 @@ impl Decoder {
         s: &Bound<PyBytes>,
         yield_tuples: Option<bool>,
         bytestring_encoding: Option<String>,
-    ) -> Self {
-        Decoder {
+    ) -> PyResult<Self> {
+        Ok(Decoder {
             data: s.as_bytes().to_vec(),
             position: 0,
             yield_tuples: yield_tuples.unwrap_or(false),
             bytestring_encoding,
-        }
+            depth: 0,
+            max_depth: recursion_limit(s.py())?,
+        })
     }
 
     fn decode<'py>(&mut self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
@@ -58,7 +71,12 @@ impl Decoder {
             return Err(PyValueError::new_err("stream underflow"));
         }
 
-        // Check for recursion - in a real implementation we would track recursion depth
+        if self.depth > self.max_depth {
+            return Err(PyRecursionError::new_err(
+                "maximum recursion depth exceeded while decoding bencode",
+            ));
+        }
+
         let next_byte = self.data[self.position];
 
         match next_byte {
@@ -189,6 +207,7 @@ impl Decoder {
     }
 
     fn decode_list<'py>(&mut self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+        self.depth += 1;
         let mut result = Vec::new();
 
         while self.position < self.data.len() && self.data[self.position] != b'e' {
@@ -202,6 +221,7 @@ impl Decoder {
 
         // Skip the 'e'
         self.position += 1;
+        self.depth -= 1;
 
         if self.yield_tuples {
             let tuple = PyTuple::new(py, &result)?;
@@ -213,6 +233,7 @@ impl Decoder {
     }
 
     fn decode_dict<'py>(&mut self, py: Python<'py>) -> PyResult<Bound<'py, PyDict>> {
+        self.depth += 1;
         let dict = PyDict::new(py);
         let mut last_key: Option<Vec<u8>> = None;
 
@@ -261,6 +282,7 @@ impl Decoder {
 
         // Skip the 'e'
         self.position += 1;
+        self.depth -= 1;
 
         Ok(dict)
     }
@@ -270,16 +292,24 @@ impl Decoder {
 struct Encoder {
     buffer: Vec<u8>,
     bytestring_encoding: Option<String>,
+    depth: usize,
+    max_depth: usize,
 }
 
 #[pymethods]
 impl Encoder {
     #[new]
-    fn new(_maxsize: Option<usize>, bytestring_encoding: Option<String>) -> Self {
-        Encoder {
+    fn new(
+        py: Python,
+        _maxsize: Option<usize>,
+        bytestring_encoding: Option<String>,
+    ) -> PyResult<Self> {
+        Ok(Encoder {
             buffer: Vec::new(),
             bytestring_encoding,
-        }
+            depth: 0,
+            max_depth: recursion_limit(py)?,
+        })
     }
 
     fn to_bytes<'py>(&self, py: Python<'py>) -> Bound<'py, PyBytes> {
@@ -287,6 +317,11 @@ impl Encoder {
     }
 
     fn process(&mut self, py: Python, x: Bound<PyAny>) -> PyResult<()> {
+        if self.depth > self.max_depth {
+            return Err(PyRecursionError::new_err(
+                "maximum recursion depth exceeded while encoding bencode",
+            ));
+        }
         if let Ok(s) = x.extract::<Bound<PyBytes>>() {
             self.encode_bytes(s)?;
         } else if let Ok(n) = x.extract::<i64>() {
@@ -355,6 +390,7 @@ impl Encoder {
     }
 
     fn encode_list(&mut self, py: Python, sequence: Bound<PyAny>) -> PyResult<()> {
+        self.depth += 1;
         self.buffer.push(b'l');
 
         for item in sequence.try_iter()? {
@@ -362,10 +398,12 @@ impl Encoder {
         }
 
         self.buffer.push(b'e');
+        self.depth -= 1;
         Ok(())
     }
 
     fn encode_dict(&mut self, py: Python, dict: Bound<PyDict>) -> PyResult<()> {
+        self.depth += 1;
         self.buffer.push(b'd');
 
         // Get all keys and sort them
@@ -393,38 +431,39 @@ impl Encoder {
         }
 
         self.buffer.push(b'e');
+        self.depth -= 1;
         Ok(())
     }
 }
 
 #[pyfunction]
 fn bdecode<'py>(py: Python<'py>, s: &Bound<PyBytes>) -> PyResult<Bound<'py, PyAny>> {
-    let mut decoder = Decoder::new(s, None, None);
+    let mut decoder = Decoder::new(s, None, None)?;
     decoder.decode(py)
 }
 
 #[pyfunction]
 fn bdecode_as_tuple<'py>(py: Python<'py>, s: &Bound<PyBytes>) -> PyResult<Bound<'py, PyAny>> {
-    let mut decoder = Decoder::new(s, Some(true), None);
+    let mut decoder = Decoder::new(s, Some(true), None)?;
     decoder.decode(py)
 }
 
 #[pyfunction]
 fn bdecode_utf8<'py>(py: Python<'py>, s: &Bound<PyBytes>) -> PyResult<Bound<'py, PyAny>> {
-    let mut decoder = Decoder::new(s, None, Some("utf-8".to_string()));
+    let mut decoder = Decoder::new(s, None, Some("utf-8".to_string()))?;
     decoder.decode(py)
 }
 
 #[pyfunction]
 fn bencode(py: Python, x: Bound<PyAny>) -> PyResult<Py<PyAny>> {
-    let mut encoder = Encoder::new(None, None);
+    let mut encoder = Encoder::new(py, None, None)?;
     encoder.process(py, x)?;
     Ok(encoder.to_bytes(py).into())
 }
 
 #[pyfunction]
 fn bencode_utf8(py: Python, x: Bound<PyAny>) -> PyResult<Py<PyAny>> {
-    let mut encoder = Encoder::new(None, Some("utf-8".to_string()));
+    let mut encoder = Encoder::new(py, None, Some("utf-8".to_string()))?;
     encoder.process(py, x)?;
     Ok(encoder.to_bytes(py).into())
 }

--- a/tests/test_bencode.py
+++ b/tests/test_bencode.py
@@ -300,6 +300,10 @@ class TestBencodeDecode(TestCase):
             for i in range(99):
                 expected = [expected]
             self._check(expected, (b"l" * 100) + (b"e" * 100))
+            with RecursionLimit():
+                self._run_check_error(
+                    RuntimeError, (b"l" * 1000) + (b"e" * 1000)
+                )
         else:
             with RecursionLimit():
                 self._run_check_error(
@@ -323,9 +327,6 @@ class TestBencodeDecode(TestCase):
         )
 
     def test_dict_deepnested(self):
-        if self.id().endswith("(C)"):
-            self.skipTest("no limit recursion in Rust code")
-
         with RecursionLimit():
             self._run_check_error(
                 RuntimeError, (b"d0:" * 1000) + b"i1e" + (b"e" * 1000)
@@ -437,9 +438,6 @@ class TestBencodeEncode(TestCase):
         self._check(b"ll5:Alice3:Bobeli2ei3eee", ((b"Alice", b"Bob"), (2, 3)))
 
     def test_list_deep_nested(self):
-        if self.id().endswith("(C)"):
-            self.skipTest("no limit recursion in Rust code")
-
         top = []
         lst = top
         for unused_i in range(1000):
@@ -457,9 +455,6 @@ class TestBencodeEncode(TestCase):
         )
 
     def test_dict_deep_nested(self):
-        if self.id().endswith("(C)"):
-            self.skipTest("no limit of recursion in Rust code")
-
         d = top = {}
         for i in range(1000):
             d[b""] = {}


### PR DESCRIPTION
The Rust `Decoder` and `Encoder` recurse without tracking depth, so deeply
nested input overflows the native stack and crashes the process instead of
raising. The pure-Python backend raises a catchable `RecursionError` on the
same input, so the two backends disagree:

```python
>>> from fastbencode import _bencode_py, _bencode_rs
>>> _bencode_py.bdecode(b'l' * 100000 + b'e' * 100000)   # RecursionError
>>> _bencode_rs.bdecode(b'l' * 100000 + b'e' * 100000)   # SIGSEGV
```

The same is true for nested dicts and for `bencode()` of a deeply nested
list/dict. This is the gap noted by the `decode_object` TODO ("in a real
implementation we would track recursion depth") and by the three deep-nesting
tests that are skipped for the C extension with "no limit recursion in Rust
code" (#98).

This tracks the nesting depth in both `Decoder` and `Encoder` and raises
`RecursionError` once it passes `sys.getrecursionlimit()`, read once when the
decoder/encoder is created. Using the interpreter's limit keeps the two
backends in agreement, including under a lowered limit — which is what the
`RecursionLimit` test helper relies on. Only entering a container increments
the counter, so a flat list/dict of many elements is unaffected.

The three skipped tests are un-skipped and a deep-list decode case is added, so
all four nested shapes (decode/encode × list/dict) are now exercised against
both backends. The full suite passes for the pure-Python and Rust backends.
